### PR TITLE
Fix typo in name of merged library

### DIFF
--- a/pylokit/lokit.py
+++ b/pylokit/lokit.py
@@ -11,7 +11,7 @@ import six
 import os
 
 
-TARGET_LIB = ("libsofficeapp.so", "liblibmergedlo.so")
+TARGET_LIB = ("libsofficeapp.so", "libmergedlo.so")
 
 LOKIT_CDEFS = """
 typedef struct _LibreOfficeKit LibreOfficeKit;


### PR DESCRIPTION
Probably carried over from a typo in lloconv, which I fixed in b9e86c8d726ec769f4aea0db5cc2c973ed73a526.